### PR TITLE
Restricted gulp-header to 1.8.2 as 1.8.3 breaks gulp-ng-templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-ng-templates",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Build all of your angular templates in just one js file using $templateCache provider",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "event-stream": "^3.1.7",
     "gulp-concat": "^2.3.4",
     "gulp-footer": "^1.0.5",
-    "gulp-header": "^1.0.5",
+    "gulp-header": "<=1.8.2",
     "gulp-util": "^3.0.1",
     "jade": "^1.7.0",
     "js-string-escape": "^1.0.0",


### PR DESCRIPTION
This fixes an issue with the latest gulp-header which breaks gulp-ng-templates triggering the following error:

```
fs.js:839
  return binding.lstat(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, lstat '/home/project-barbie/build/source/js/main/directives/partials/templates.min.js'
    at Error (native)
    at Object.fs.lstatSync (fs.js:839:18)
    at DestroyableTransform.TransformStream [as _transform] (/home/project-barbie/node_modules/gulp-ng-templates/node_modules/gulp-header/index.js:38:12)
    at DestroyableTransform.Transform._read (/home/project-barbie/node_modules/gulp-ng-templates/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:159:10)
    at DestroyableTransform.Transform._write (/home/project-barbie/node_modules/gulp-ng-templates/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:147:83)
    at doWrite (/home/project-barbie/node_modules/gulp-ng-templates/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:313:64)
    at writeOrBuffer (/home/project-barbie/node_modules/gulp-ng-templates/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:302:5)
    at DestroyableTransform.Writable.write (/home/project-barbie/node_modules/gulp-ng-templates/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:241:11)
    at write (/home/project-barbie/node_modules/gulp-concat/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/home/project-barbie/node_modules/gulp-concat/node_modules/readable-stream/lib/_stream_readable.js:632:7)
```
